### PR TITLE
Breed select button added. Accordion modified to show only one item o…

### DIFF
--- a/src/List.js
+++ b/src/List.js
@@ -12,6 +12,9 @@ import {
   Typography,
   CircularProgress,
   Grid,
+  Button,
+  Divider,
+  Box
 } from "@material-ui/core";
 import { ExpandMore as ExpandMoreIcon, Pets } from "@material-ui/icons";
 import { makeStyles } from "@material-ui/core/styles";
@@ -25,8 +28,15 @@ const useStyles = makeStyles({
 });
 const MyList = (props) => {
   const classes = useStyles();
-  const { breedName, setBreedName } = props;
+  const { breedName, setBreedName,setValue } = props;
   const [breeds, setBreeds] = useState(undefined);
+
+  const [expandedPanel, setExpandedPanel] = useState(false);
+
+  const handleAccordionChange = (key) => (event, isExpanded) => {
+    setExpandedPanel(isExpanded ? key : false);
+  };
+
   useEffect(() => {
     axios.get("https://dog.ceo/api/breeds/list/all").then((response) => {
       console.log(response.data.message);
@@ -45,6 +55,8 @@ const MyList = (props) => {
               onClick={() => {
                 setBreedName(key);
               }}
+              expanded={expandedPanel === key} 
+              onChange={handleAccordionChange(key)}
             >
               <AccordionSummary
                 expandIcon={<ExpandMoreIcon />}
@@ -72,12 +84,18 @@ const MyList = (props) => {
                             <Pets />
                           </Avatar>
                         </ListItemAvatar>
-                        <ListItemText primary={breed} />
+                        <ListItemText primary={breed} />                       
                       </ListItem>
                     ))
-                  )}
+                  )}              
                 </List>
               </AccordionDetails>
+              <Divider />
+              <Box p={2}>
+                  <Button variant="contained" color="secondary" onClick={() => setValue(1)} >
+                    Select
+                  </Button>
+              </Box>
             </Accordion>
           );
         })

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -62,7 +62,7 @@ export default function SimpleTabs() {
       </AppBar>
       <Paper>
         <TabPanel value={value} index={0}>
-          <MyList {...{ breedName, setBreedName }} />
+          <MyList {...{ breedName, setBreedName,value,setValue }} />
         </TabPanel>
         <TabPanel value={value} index={1}>
           <Image {...{ breedName }} />


### PR DESCRIPTION
1. A button added to the breed list panel that redirects to the second panel
2. Accordion modified so that only one active item is open at any time. ( I understand this was not a listed item. However, I thought it would be an improvement in UX)

![Dog-Book](https://user-images.githubusercontent.com/1711057/95475475-e159a580-09a3-11eb-8fd4-1033466260cf.gif)
